### PR TITLE
Rename routing to transport

### DIFF
--- a/src/Moryx.ControlSystem/Transport/ITransportSystem.cs
+++ b/src/Moryx.ControlSystem/Transport/ITransportSystem.cs
@@ -6,17 +6,17 @@ using System.Collections.Generic;
 using Moryx.AbstractionLayer.Resources;
 using Moryx.ControlSystem.Processes;
 
-namespace Moryx.ControlSystem.Routing
+namespace Moryx.ControlSystem.Transport
 {
     /// <summary>
     /// Resource that can route products or workpiece groups within the machine
     /// </summary>
-    public interface IRoutingResource : IPublicResource
+    public interface ITransportSystem : IPublicResource
     {
         /// <summary>
         /// Modes supported by this routing resource
         /// </summary>
-        RoutingMode SupportedModes { get; }
+        TransportMode SupportedModes { get; }
 
         /// <summary>
         /// Get all process groups managed by this resource

--- a/src/Moryx.ControlSystem/Transport/TransportCapabilities.cs
+++ b/src/Moryx.ControlSystem/Transport/TransportCapabilities.cs
@@ -4,12 +4,12 @@
 using System.Linq;
 using Moryx.AbstractionLayer.Capabilities;
 
-namespace Moryx.ControlSystem.Routing
+namespace Moryx.ControlSystem.Transport
 {
     /// <summary>
     /// Capabilities provided by resources that can route articles or article groups wihtin the machine
     /// </summary>
-    public class RoutingCapabilities : CapabilitiesBase
+    public class TransportCapabilities : CapabilitiesBase
     {
         /// <summary>
         /// This property serves two main purpose. For the resource it contains the resources that are connected to the
@@ -21,7 +21,7 @@ namespace Moryx.ControlSystem.Routing
         /// <inheritdoc />
         protected override bool ProvidedBy(ICapabilities provided)
         {
-            var capabilities = provided as RoutingCapabilities;
+            var capabilities = provided as TransportCapabilities;
             if (capabilities == null)
                 return false;
 

--- a/src/Moryx.ControlSystem/Transport/TransportMode.cs
+++ b/src/Moryx.ControlSystem/Transport/TransportMode.cs
@@ -4,13 +4,13 @@
 using System;
 using Moryx.ControlSystem.Processes;
 
-namespace Moryx.ControlSystem.Routing
+namespace Moryx.ControlSystem.Transport
 {
     /// <summary>
     /// Flags of supported routing modes
     /// </summary>
     [Flags]
-    public enum RoutingMode
+    public enum TransportMode
     {
         /// <summary>
         /// No supported routing


### PR DESCRIPTION
As a final action before the release we switch to Transport as feedback has proven this name to be more intuitive.