### PR TITLE
Extend the IOrderManagement facade

### DIFF
--- a/src/Moryx.Orders/Facade/IOrderManagement.cs
+++ b/src/Moryx.Orders/Facade/IOrderManagement.cs
@@ -1,14 +1,18 @@
-﻿// Copyright (c) 2021, Phoenix Contact GmbH & Co. KG
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
+using Moryx.AbstractionLayer.Products;
+using Moryx.AbstractionLayer.Recipes;
+using Moryx.Orders.Advice;
 using Moryx.Users;
 
 namespace Moryx.Orders
 {
     /// <summary>
-    /// Order management facade. Exports the important events to other modules
+    /// Order management facade. Declares methods available to manage Orders in the MORYX Platform.
     /// </summary>
     public interface IOrderManagement
     {
@@ -132,5 +136,36 @@ namespace Moryx.Orders
         /// Event which will be raised when the report context of the operation will be requested
         /// </summary>
         event EventHandler<OperationReportRequestEventArgs> OperationReportRequest;
+    }
+
+    /// <summary>
+    /// Order management facade. Declares methods available to manage Orders in the MORYX Platform.
+    /// </summary>
+    public interface IOrderManagementExtended : IOrderManagement
+    {
+        /// <summary>
+        /// Assigns or updates operation related information like the corresponding product or recipes on the existing operation instance.
+        /// </summary>
+        /// <param name="operation">The <see cref="Operation"/> assign.</param>
+        void Reload(Operation operation); 
+
+        /// <summary>
+        /// Tries to advise the <see cref="Operation"/> corresponding to the <paramref name="operationId"/>. 
+        /// The returned advice result contains information regarding the successful or unsuccesful attempt.
+        /// </summary>
+        /// <param name="operation">The <see cref="Operation"/> to advice.</param>
+        /// <param name="advice">The <see cref="OperationAdvice"/> to apply on the <see cref="Operation"/>.</param>
+        Task<AdviceResult> TryAdvice(Operation operation, OperationAdvice advice);
+
+        /// <summary>
+        /// Returns an array of <see cref="OperationLogMessage"/>s corresponding to the operation.
+        /// </summary>
+        /// <param name="operation">The <see cref="Operation"/> to retrieve logs for.</param>
+        IReadOnlyCollection<OperationLogMessage> GetLogs(Operation operation);
+
+        /// <summary>
+        /// Returns a set of recipes this OrderManagement can assign to an Operation corresponding to the <paramref name="identity"/>.
+        /// </summary>
+        Task<IReadOnlyList<IProductRecipe>> GetAssignableRecipes(ProductIdentity identity);
     }
 }

--- a/src/Moryx.Orders/Facade/OrderFacadeExtensions.cs
+++ b/src/Moryx.Orders/Facade/OrderFacadeExtensions.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer.Products;
+using Moryx.AbstractionLayer.Recipes;
+using Moryx.Orders.Advice;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Moryx.Orders.Facade
+{
+    // TODO: AL6 Remove extensions
+    /// <summary>
+    /// Extensions for the <see cref="IOrderManagement"/> facade
+    /// </summary>
+    public static class OrderFacadeExtensions
+    {
+        /// <summary>
+        /// Bridge extension for assigning or updating operation related information to the <paramref name="operation"/>.
+        /// </summary>
+        /// <param name="facade">This order management instance</param>
+        /// <param name="operation">The <see cref="Operation.Identifier"/> to assign</param>
+        public static void Reload(this IOrderManagement facade, Operation operation)
+        {
+            if (facade is IOrderManagementExtended extended)
+            {
+                extended.Reload(operation);
+                return;
+            }                
+
+            throw new NotSupportedException("Instance of order management does not support assignment");
+        }
+
+        /// <summary>
+        /// Bridge extension for advising the <paramref name="operation"/>.
+        /// </summary>
+        /// <param name="facade">This order management instance</param>
+        /// <param name="operation">The <see cref="Operation"/> to advice.</param>
+        /// <param name="advice">The <see cref="OperationAdvice"/> to apply on the <paramref name="operation"/>.</param>
+        public static Task<AdviceResult> TryAdvice(this IOrderManagement facade, Operation operation, OperationAdvice advice)
+        {
+            if (facade is IOrderManagementExtended extended)
+                return extended.TryAdvice(operation, advice);
+
+            throw new NotSupportedException("Instance of order management does not support advicing");
+        }
+
+        /// <summary>
+        /// Bridge extension for retrieving an array of <see cref="OperationLogMessage"/>s corresponding to the <paramref name="operation"/>.
+        /// </summary>
+        /// <param name="facade">This order management instance</param>
+        /// <param name="operation">The <see cref="Operation"/> to advice.</param>
+        public static IReadOnlyCollection<OperationLogMessage> GetLogs(this IOrderManagement facade, Operation operation)
+        {
+            if (facade is IOrderManagementExtended extended)
+                return extended.GetLogs(operation);
+
+            throw new NotSupportedException("Instance of order management does not support retriving logs");
+        }
+
+        /// <summary>
+        /// Bridge extension for retrieving a set of recipes this OrderManagement can assign to an Operation corresponding to the 
+        /// <paramref name="identity"/>.
+        /// </summary>
+        public static Task<IReadOnlyList<IProductRecipe>> GetAssignableRecipes(this IOrderManagement facade, ProductIdentity identity)
+        {
+            if (facade is IOrderManagementExtended extended)
+                return extended.GetAssignableRecipes(identity);
+
+            throw new NotSupportedException("Instance of order management does not support retriving assignable recipes.");
+        }
+    }
+}


### PR DESCRIPTION
Add an IOrderManagementExtended interface and extension method to bridge references to IOrderManagement to the new interface. 