### PR TITLE
Added missing setter to plugin name to directly use the SetupTriggerConfig

### DIFF
--- a/src/Moryx.ControlSystem/Setups/SetupTriggerConfig.cs
+++ b/src/Moryx.ControlSystem/Setups/SetupTriggerConfig.cs
@@ -17,7 +17,7 @@ namespace Moryx.ControlSystem.Setups
         /// Name of the plugin to instantiate for this trigger
         /// </summary>
         [DataMember, PluginNameSelector(typeof(ISetupTrigger))]
-        public virtual string PluginName { get; }
+        public virtual string PluginName { get; set; }
 
         /// <summary>
         /// Sort order of the trigger instance in the resulting workplan


### PR DESCRIPTION
The `SetupTriggerConfig` cannot be used directly because the `PluginName` has no setter. Also inherit the class brings no possibility to override the property with a setter, therefore all SetupTriggers need an explicit config implementation which leads to a lot of boilerplate. Other plugins like the `ProductAssignment` or `RecipeAssignment` are providing this.