### PR TITLE
Add .net6 Target and remove Obsoletes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ env:
   MORYX_OPTIMIZE_CODE: "false"
   MORYX_BUILD_CONFIG: "Release"
   MORYX_BUILDNUMBER: ${{github.run_number}}
-  dotnet_sdk_version: '5.0.403'
+  dotnet_sdk_version: '6.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 
 jobs:
@@ -27,16 +27,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup .NET SDK
-        if: ${{ github.ref != 'refs/heads/future' }} # Future branch uses net6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.dotnet_sdk_version }}
-          
-      - name: Setup .NET SDK
-        if: ${{ github.ref == 'refs/heads/future' }} # Future branch uses net6
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6'
 
       - name: Build
         shell: pwsh
@@ -56,16 +49,9 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Setup .NET SDK
-        if: ${{ github.ref != 'refs/heads/future' }} # Future branch uses net6
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ env.dotnet_sdk_version }}
-          
-      - name: Setup .NET SDK
-        if: ${{ github.ref == 'refs/heads/future' }} # Future branch uses net6
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '6'
 
       - name: Execute Unit Tests
         shell: pwsh

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,8 +3,8 @@
 
   <!-- Central package version management -->
   <PropertyGroup>
-    <MoryxCoreVersion>4.0.0-future.533</MoryxCoreVersion>
-    <MoryxAbstractionLayerVersion>6.0.0-future.550</MoryxAbstractionLayerVersion>
+    <MoryxCoreVersion>4.0.0-future.617</MoryxCoreVersion>
+    <MoryxAbstractionLayerVersion>6.0.0-future.580</MoryxAbstractionLayerVersion>
   </PropertyGroup>
 
   <Import Project=".build\Common.props" Condition="'$(CreatePackage)' == 'true'" />

--- a/src/Moryx.ControlSystem/Moryx.ControlSystem.csproj
+++ b/src/Moryx.ControlSystem/Moryx.ControlSystem.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Bundle assembly for ControlSystem and extensions</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.ControlSystem/Setups/ISetupTrigger.cs
+++ b/src/Moryx.ControlSystem/Setups/ISetupTrigger.cs
@@ -5,7 +5,7 @@ using Moryx.AbstractionLayer.Capabilities;
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Collections;
 using Moryx.Modules;
-using Moryx.Workflows;
+using Moryx.Workplans;
 
 namespace Moryx.ControlSystem.Setups
 {

--- a/src/Moryx.ControlSystem/Setups/SetupTriggerBase.cs
+++ b/src/Moryx.ControlSystem/Setups/SetupTriggerBase.cs
@@ -4,7 +4,7 @@
 using Moryx.AbstractionLayer.Recipes;
 using Moryx.Bindings;
 using Moryx.Logging;
-using Moryx.Workflows;
+using Moryx.Workplans;
 
 namespace Moryx.ControlSystem.Setups
 {

--- a/src/Moryx.Orders/Documents/WebDocument.cs
+++ b/src/Moryx.Orders/Documents/WebDocument.cs
@@ -40,15 +40,10 @@ namespace Moryx.Orders.Documents
         /// <inheritdoc />
         public override Stream GetStream()
         {
-            var getTask = Task.Run(() => _client.GetAsync(Url));
-            getTask.Wait();
-            var response = getTask.Result;
-            
-            var readTask = Task.Run(() => response.Content.ReadAsStreamAsync());
-            readTask.Wait();
-
+            var response = _client.GetAsync(Url).Result;
             ContentType = response.Content.Headers.ContentType.MediaType;
-            return readTask.Result;
+
+            return response.Content.ReadAsStreamAsync().Result;
         }
     }
 }

--- a/src/Moryx.Orders/Moryx.Orders.csproj
+++ b/src/Moryx.Orders/Moryx.Orders.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Bundle assembly for Orders and extensions</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.ProcessData/Moryx.ProcessData.csproj
+++ b/src/Moryx.ProcessData/Moryx.ProcessData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Bundle assembly for process data and listeners</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Moryx.Users/Moryx.Users.csproj
+++ b/src/Moryx.Users/Moryx.Users.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Bundle assembly for Users and extensions</Description>
     <CreatePackage>true</CreatePackage>

--- a/src/Tests/Moryx.ControlSystem.Tests/Moryx.ControlSystem.Tests.csproj
+++ b/src/Tests/Moryx.ControlSystem.Tests/Moryx.ControlSystem.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>full</DebugType>
   </PropertyGroup>

--- a/src/Tests/Moryx.ProcessData.Tests/Moryx.ProcessData.Tests.csproj
+++ b/src/Tests/Moryx.ProcessData.Tests/Moryx.ProcessData.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <DebugType>full</DebugType>
   </PropertyGroup>

--- a/src/Tests/Moryx.ProcessData.Tests/ProcessDataListenerTests.cs
+++ b/src/Tests/Moryx.ProcessData.Tests/ProcessDataListenerTests.cs
@@ -25,7 +25,7 @@ namespace Moryx.ProcessData.Tests
                 CallBase = true
             };
 
-            _listenerMock.Object.Logger = new ModuleLogger("Dummy", typeof(ProcessDataListenerBase), new NullLoggerFactory());
+            _listenerMock.Object.Logger = new ModuleLogger("Dummy", new NullLoggerFactory());
 
             _listenerConfig = new ProcessDataListenerConfig();
             _listenerMock.Object.Initialize(_listenerConfig);


### PR DESCRIPTION
We jump to the latest LTS version of .net with these changes. 

Breaking change related information:
https://learn.microsoft.com/en-us/dotnet/core/compatibility/networking/6.0/webrequest-deprecated