### PR TITLE
Added unittests and fixed EnumInstructionResult

### DIFF
--- a/src/Moryx.ControlSystem/Properties/AssemblyInfo.cs
+++ b/src/Moryx.ControlSystem/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Moryx.ControlSystem.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/src/Moryx.ControlSystem/VisualInstructions/EnumInstructionResult.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/EnumInstructionResult.cs
@@ -28,8 +28,8 @@ namespace Moryx.ControlSystem.VisualInstructions
         {
             _callback = callback;
 
+            var allHidden = true;
             var allValues = new Dictionary<string, int>();
-
             foreach (var name in Enum.GetNames(resultEnum).Except(exceptions))
             {
                 var member = resultEnum.GetMember(name)[0];
@@ -38,12 +38,19 @@ namespace Moryx.ControlSystem.VisualInstructions
                 var text = attribute?.Title ?? name;
                 allValues[text] = (int)Enum.Parse(resultEnum, name);
 
-                if (attribute != null && !attribute.Hide)
+                if(attribute == null)
+                {
+                    allHidden = false;
+                }
+                else if(!attribute.Hide)
+                {
+                    allHidden = false;
                     _valueMap[text] = allValues[text];
+                }
             }
 
             // If we found no entries, the display attribute was not used and we take all entries
-            if (_valueMap.Count == 0)
+            if (_valueMap.Count == 0 && !allHidden)
                 _valueMap = allValues;
         }
 

--- a/src/Tests/Moryx.ControlSystem.Tests/EnumInstructionResultTests.cs
+++ b/src/Tests/Moryx.ControlSystem.Tests/EnumInstructionResultTests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) 2021, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.ControlSystem.VisualInstructions;
+using NUnit.Framework;
+using System.Linq;
+
+namespace Moryx.ControlSystem.Tests
+{
+    [TestFixture]
+    public class EnumInstructionResultTests
+    {
+        private enum TestResults1
+        {
+            Value1,
+            Value2
+        }
+
+        [Test]
+        public void GetAllValuesIfNoResultIsDecorated()
+        {
+            // Act
+            var instructionResult = new EnumInstructionResult(typeof(TestResults1), result => { });
+
+            // Assert
+            Assert.AreEqual(2, instructionResult.Results.Count(), "There should be 2 results because all of the results are not decorated");
+        }
+
+        private enum TestResults2
+        {
+            [EnumInstruction("Value1")]
+            Value1,
+            [EnumInstruction("Value2")]
+            Value2
+        }
+
+        [Test]
+        public void GetAllValuesIfAllResultsAreDecorated()
+        {
+            // Act
+            var instructionResult = new EnumInstructionResult(typeof(TestResults2), result => { });
+
+            // Assert
+            Assert.AreEqual(2, instructionResult.Results.Count(), "There should be 2 results because all of the results are decorated");
+        }
+
+        private enum TestResults3
+        {
+            [EnumInstruction("Value1")]
+            Value1,
+            Value2
+        }
+
+        [Test]
+        public void GetValuesWithAnAttribute()
+        {
+            // Act
+            var instructionResult = new EnumInstructionResult(typeof(TestResults3), result => { });
+
+            // Assert
+            Assert.AreEqual(1, instructionResult.Results.Count(), "There should be 1 result because only one value is decorated");
+        }
+
+        private enum TestResults4
+        {
+            [EnumInstruction("Value1", Hide = true)]
+            Value1,
+            Value2
+        }
+
+        [Test]
+        public void GetAllValuesIfThereAreHiddenAndNotDecoratedResults()
+        {
+            // Act
+            var instructionResult = new EnumInstructionResult(typeof(TestResults4), result => { });
+
+            // Assert
+            Assert.AreEqual(2, instructionResult.Results.Count(), "There should be no results because there are hidden and not decorated results");
+        }
+
+        private enum TestResults5
+        {
+            [EnumInstruction("Value1", Hide = true)]
+            Value1,
+            [EnumInstruction("Value2", Hide = true)]
+            Value2
+        }
+
+        [Test]
+        public void GetNoValuesIfAllResultsAreHidden()
+        {
+            // Act
+            var instructionResult = new EnumInstructionResult(typeof(TestResults5), result => { });
+
+            // Assert
+            Assert.AreEqual(0, instructionResult.Results.Count(), "There should be no results because all of them are hidden");
+        }
+    }
+}

--- a/src/Tests/Moryx.ControlSystem.Tests/Moryx.ControlSystem.Tests.csproj
+++ b/src/Tests/Moryx.ControlSystem.Tests/Moryx.ControlSystem.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="NUnit" />
+	<PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Moq" />
 
     <PackageReference Include="Moryx.AbstractionLayer.TestTools" />

--- a/src/Tests/Moryx.ControlSystem.Tests/ProductionSessionTests.cs
+++ b/src/Tests/Moryx.ControlSystem.Tests/ProductionSessionTests.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 
 namespace Moryx.ControlSystem.Tests
 {
+
     [TestFixture]
     public class ProductionSessionTests
     {

--- a/src/Tests/Moryx.ControlSystem.Tests/Properties/AssemblyInfo.cs
+++ b/src/Tests/Moryx.ControlSystem.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
In case that all results are decorated with an EnumInstruction attribute and set to hidden. Then the returned list should be empty instead of containing all results.

