### PR TITLE
Add position type for recipe append

### DIFF
--- a/src/Moryx.ControlSystem/Jobs/JobPositionType.cs
+++ b/src/Moryx.ControlSystem/Jobs/JobPositionType.cs
@@ -32,5 +32,10 @@ namespace Moryx.ControlSystem.Jobs
         /// The new jobs surround existing ones
         /// </summary>
         AroundExisting = 4,
+
+        /// <summary>
+        /// Append job(s) to group of jobs with the same recipe
+        /// </summary>
+        AppendToRecipe = 5,
     }
 }


### PR DESCRIPTION
In many cases users want to append follow-up jobs for scrap parts and struggle with correct positioning and race conditions. This lets the job list pick the best position for the follow-up