### PR TITLE
Prepare new API for user input for instructions

### DIFF
--- a/src/Moryx.ControlSystem/VisualInstructions/ActiveInstruction.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/ActiveInstruction.cs
@@ -24,6 +24,11 @@ namespace Moryx.ControlSystem.VisualInstructions
         public VisualInstruction[] Instructions { get; set; }
 
         /// <summary>
+        /// Optional input object
+        /// </summary>
+        public object Inputs { get; set; }
+
+        /// <summary>
         /// Results of the instruction
         /// </summary>
         public string[] PossibleResults { get; set; } = new string[0];

--- a/src/Moryx.ControlSystem/VisualInstructions/ActiveInstructionResponse.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/ActiveInstructionResponse.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2022, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Moryx.ControlSystem.VisualInstructions
+{
+    /// <summary>
+    /// Response of the client for an <see cref="ActiveInstruction"/>
+    /// </summary>
+    public class ActiveInstructionResponse
+
+    {
+        /// <summary>
+        /// Runtime unique identifier of this instruction per client-identifier
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// Optional inputs provided by the user
+        /// </summary>
+        public object Inputs { get; set; }
+
+        /// <summary>
+        /// Selected result option by the user
+        /// </summary>
+        public string Result { get; set; }
+    }
+}

--- a/src/Moryx.ControlSystem/VisualInstructions/EnumInstructionResult.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/EnumInstructionResult.cs
@@ -10,23 +10,38 @@ namespace Moryx.ControlSystem.VisualInstructions
     /// <summary>
     /// Represents an <see cref="IInstructionResults"/> which will handle enums to generate results and convert them back
     /// </summary>
-    public class EnumInstructionResult : IInstructionResults
+    public class EnumInstructionResult : IInstructionInputResults
     {
-        private readonly Action<int> _callback;
+        private readonly Action<int, object> _callback;
         private readonly Dictionary<string, int> _valueMap = new Dictionary<string, int>();
 
         /// <inheritdoc />
         public string[] Results => _valueMap.Keys.ToArray();
 
+        /// <inheritdoc />
+        public object Input { get; private set; }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="EnumInstructionResult"/>
+        /// </summary>
+        [Obsolete("Use constructor with input object instead")]
+        public EnumInstructionResult(Type resultEnum, Action<int> callback, params string[] exceptions)
+            : this(resultEnum, null, (result, input) => callback(result), exceptions)
+        {
+        }
+
         /// <summary>
         /// Creates a new instance of <see cref="EnumInstructionResult"/>
         /// </summary>
         /// <param name="resultEnum">Enum type which will be used to create instruction results</param>
+        /// <param name="inputs">Input object</param>
         /// <param name="callback">Callback with enum result value of the executed instruction</param>
         /// <param name="exceptions">Excepted enum value names. Will be ignored for result</param>
-        public EnumInstructionResult(Type resultEnum, Action<int> callback, params string[] exceptions)
+        public EnumInstructionResult(Type resultEnum, object inputs, Action<int, object> callback, params string[] exceptions)
         {
             _callback = callback;
+
+            Input = inputs;
 
             var allHidden = true;
             var allValues = new Dictionary<string, int>();
@@ -58,11 +73,20 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Invokes the callback with the given string result
         /// Will parse the string to the enum value
         /// </summary>
-        /// <param name="result"></param>
         public virtual void Invoke(string result)
         {
             var enumValue = _valueMap[result];
-            _callback(enumValue);
+            _callback(enumValue, null);
+        }
+
+        /// <summary>
+        /// Invokes the callback with the given string result
+        /// Will parse the string to the enum value
+        /// </summary>
+        public void Invoke(string result, object input)
+        {
+            var enumValue = _valueMap[result];
+            _callback(enumValue, input);
         }
     }
 }

--- a/src/Moryx.ControlSystem/VisualInstructions/IInstructionResults.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/IInstructionResults.cs
@@ -22,4 +22,21 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// </summary>
         void Invoke(string result);
     }
+
+    /// <summary>
+    /// Extended interface for instructions that support user input
+    /// This will be merged with <see cref="IInstructionResults"/> in MORYX 8
+    /// </summary>
+    public interface IInstructionInputResults : IInstructionResults
+    {
+        /// <summary>
+        /// Prepared input object to be filled by the user
+        /// </summary>
+        object Input { get; }
+
+        /// <summary>
+        /// Extended <see cref="IInstructionResults.Invoke(string)"/> with filled input object
+        /// </summary>
+        void Invoke(string result, object input);
+    }
 }

--- a/src/Moryx.ControlSystem/VisualInstructions/IVisualInstructionSource.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/IVisualInstructionSource.cs
@@ -25,6 +25,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// <summary>
         /// An instruction was completed
         /// </summary>
+        [Obsolete("Use Completed from IVisualInstructionSourceResponse with response object instead.")]
         void Completed(long id, string result);
 
         /// <summary>
@@ -36,5 +37,16 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Instruction was cleared
         /// </summary>
         event EventHandler<ActiveInstruction> Cleared;
+    }
+
+    /// <summary>
+    /// Extended interface for <see cref="IVisualInstructionSource"/> that uses the new response argument
+    /// </summary>
+    public interface IVisualInstructionSourceResponse : IVisualInstructionSource
+    {
+        /// <summary>
+        /// An instruction was completed
+        /// </summary>
+        void Completed(ActiveInstructionResponse response);
     }
 }

--- a/src/Moryx.ControlSystem/VisualInstructions/IWorkerSupport.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/IWorkerSupport.cs
@@ -29,6 +29,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// <summary>
         /// Complete an instruction with the selected result
         /// </summary>
+        [Obsolete("Use CompleteInstruction with the response object instead")]
         void CompleteInstruction(string identifier, long instructionId, string result);
 
         /// <summary>
@@ -45,5 +46,16 @@ namespace Moryx.ControlSystem.VisualInstructions
 		/// Get a list of all available instructors
 		/// </summary>
 		public IReadOnlyList<string> GetInstructors();
+    }
+
+    /// <summary>
+    /// Extended interface for <see cref="IWorkerSupport"/>
+    /// </summary>
+    public interface IWorkerSupportInputs : IWorkerSupport
+    {
+        /// <summary>
+        /// Complete an instruction with the response received from the client
+        /// </summary>
+        void CompleteInstruction(string identifier, ActiveInstructionResponse response);
     }
 }

--- a/src/Tests/Moryx.ControlSystem.Tests/EnumInstructionResultTests.cs
+++ b/src/Tests/Moryx.ControlSystem.Tests/EnumInstructionResultTests.cs
@@ -95,5 +95,26 @@ namespace Moryx.ControlSystem.Tests
             // Assert
             Assert.AreEqual(0, instructionResult.Results.Count(), "There should be no results because all of them are hidden");
         }
+
+        [Test]
+        public void ProvidePopulatedInputs()
+        {
+            // Arrange
+            int value = 0;
+            var input = new MyInput();
+            var instructionResult = new EnumInstructionResult(typeof(TestResults1), input, (result, inputs) => value = ((MyInput)inputs).Foo);
+
+            // Act
+            Assert.NotNull(instructionResult.Input);
+            instructionResult.Invoke("Value1", new MyInput { Foo = 42 });
+
+            // Assert
+            Assert.AreEqual(42, value);
+        }
+
+        private class MyInput
+        {
+            public int Foo { get; set; }
+        }
     }
 }


### PR DESCRIPTION
This PR extends the APIs for WorkerSupport and Instructor to provide an object that should be populated by user input on the UI.

@1nf0rmagician I will merge this to use the CI for validation, please do "retro review" and we can integrate your remarks before the release next friday.