### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    open-pull-requests-limit: 10
+    schedule:
+      interval: "weekly"
+      # Check for nuget updates on Fridays
+      day: "friday"
+      time: "08:00"
+      timezone: "Europe/Berlin"
+    # Labels on pull requests for security and version updates
+    labels:
+      - "nuget" 
+      - "dependencies"
+    ignore:
+      - dependency-name: "Moryx.AbstractionLayer"


### PR DESCRIPTION
For more configuration of dependabot see https://docs.github.com/de/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

Configured Dependabot to search for nuget updates every friday at 8 am.

You can see the dependabot PRs that will be created at the [fork repo](https://github.com/jsonBackup/MORYX-Factory/pulls)