### PR TITLE
Switch CreatePackage flag with new IsPackable flag

### DIFF
--- a/src/Moryx.ControlSystem/Moryx.ControlSystem.csproj
+++ b/src/Moryx.ControlSystem/Moryx.ControlSystem.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Bundle assembly for ControlSystem and extensions</Description>
-    <CreatePackage>true</CreatePackage>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Moryx.Orders/Moryx.Orders.csproj
+++ b/src/Moryx.Orders/Moryx.Orders.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Bundle assembly for Orders and extensions</Description>
-    <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Manufacturing;Industrial</PackageTags>
   </PropertyGroup>
 

--- a/src/Moryx.ProcessData/Moryx.ProcessData.csproj
+++ b/src/Moryx.ProcessData/Moryx.ProcessData.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Bundle assembly for process data and listeners</Description>
-    <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Manufacturing;Industrial</PackageTags>
   </PropertyGroup>
 

--- a/src/Moryx.Users/Moryx.Users.csproj
+++ b/src/Moryx.Users/Moryx.Users.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Bundle assembly for Users and extensions</Description>
-    <CreatePackage>true</CreatePackage>
     <PackageTags>MORYX;Manufacturing;Industrial</PackageTags>
   </PropertyGroup>
 

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
### Summary

Delete old CreatePackage flags because it is outdated.
New flag would be IsPackable, which is true per default, so it is necessary to be set false, if a project is not to be packed.

Furthermore, added a Directory.Build.props to the Tests-directory (src/Tests/) to disable packaging for all test projects in the directory.

### Review

<!-- 
The bullet points will be edited by the reviewer 
-->

**Typical tasks**

- [ ] Merge-Request is well described
- [ ] Critical sections are *documented in code*
- [ ] *Tests* are extended
- [ ] *Documentation* is created / updated
- [ ] Running in test environment

**Clean code**

- [ ] *All* unused references are removed
- [ ] Clean code rules are respected with passion (naming, ...)
- [ ] Avoid *copy and pasted* code snippets
