### PR TITLE
Add extended setup trigger for multiple tasks

### DIFF
--- a/docs/articles/ControlSystem/SetupTriggers.md
+++ b/docs/articles/ControlSystem/SetupTriggers.md
@@ -34,6 +34,10 @@ IWorkplanStep CreateStep(IProductionRecipe recipe);
 
 Provided that `Evaluate` indicates the need for a machine change, this method creates a `WorkplanStep` to alter a target resource in a way that it provides the necessary capabilities afterwards.
 
+**Return multiple setup steps**
+
+With the extended interface `IMultiSetupTrigger.CreateSteps` it is possible to return an array of steps.
+
 ### Example of Setup Trigger using the WatchProduct example
 
 #### Preconditions
@@ -52,7 +56,7 @@ The SetupManager now knows whether he has to call the CreateStep Method of the t
 ```cs
 [ExpectedConfig(typeof(WatchFaceMountSetupTriggerConfig))]
 [Plugin(LifeCycle.Transient, typeof(ISetupTrigger), Name = nameof(WatchFaceMountSetupTrigger))]
-internal class WatchFaceMountSetupTrigger : SetupTriggerBase<WatchFaceMountSetupTriggerConfig>
+internal class WatchFaceMountSetupTrigger : SetupTriggerBase<WatchFaceMountSetupTriggerConfig>, IMultiSetupTrigger
 {
     public override SetupExecution Execution => SetupExecution.BeforeProduction;
 
@@ -73,6 +77,21 @@ internal class WatchFaceMountSetupTrigger : SetupTriggerBase<WatchFaceMountSetup
                 FinishedOrderNumber = ((WatchRecipe)recipe).OrderNumber
             }
         };
+    }
+
+    // Optional method for more than one setup task
+    public IReadOnlyList<IWorkplanStep> CreateSteps(IProductRecipe recipe)
+    {
+        return new IWorkplanStep[] 
+        { 
+            new WatchFaceMountSetupTask
+            {
+                Parameters = new WatchFaceMountSetupParameters()
+                {
+                    FinishedOrderNumber = ((WatchRecipe)recipe).OrderNumber
+                }
+            };
+        }
     }
 }
 ```

--- a/src/Moryx.ControlSystem/Setups/ISetupTrigger.cs
+++ b/src/Moryx.ControlSystem/Setups/ISetupTrigger.cs
@@ -6,6 +6,8 @@ using Moryx.AbstractionLayer.Recipes;
 using Moryx.Collections;
 using Moryx.Modules;
 using Moryx.Workplans;
+using System;
+using System.Collections.Generic;
 
 namespace Moryx.ControlSystem.Setups
 {
@@ -28,6 +30,18 @@ namespace Moryx.ControlSystem.Setups
         /// <summary>
         /// Create a setup task that performs the necessary setup actions
         /// </summary>
+        [Obsolete("This method will be replaced by CreateSteps from IMultiSetupTrigger in the next version")]
         IWorkplanStep CreateStep(IProductRecipe recipe);
+    }
+
+    /// <summary>
+    /// Extended interface for more flexbile setup triggers
+    /// </summary>
+    public interface IMultiSetupTrigger : ISetupTrigger
+    {
+        /// <summary>
+        /// Create a list of setup tasks that performs the necessary setup actions
+        /// </summary>
+        IReadOnlyList<IWorkplanStep> CreateSteps(IProductRecipe recipe);
     }
 }


### PR DESCRIPTION
Currently we need to configure triggers for different materials several times, even tough they could determine all necessary materials for a job from the product and recipe in a single run. This also allows for setting up two cells together in one step and generally gives more flexibility.