### PR TITLE
Replaced string[]  method parameters with IReadOnlyList<string> in VisualInstructorExtensions

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,7 +10,7 @@
 
   <!-- Package refereces for all projects if CreatePackage=true -->
   <ItemGroup Condition="'$(CreatePackage)' == 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Package versions for package references across all projects -->
@@ -20,7 +20,7 @@
 	<PackageReference Update="Moq" Version="4.20.69" />
 	<PackageReference Update="NUnit" Version="3.14.0" />
 	<PackageReference Update="NUnit3TestAdapter" Version="4.5.0" />
-  <PackageReference Update="coverlet.collector" Version="3.2.0" >
+  <PackageReference Update="coverlet.collector" Version="6.0.0" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
   </PackageReference>

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Reflection;
 using Moryx.AbstractionLayer;
@@ -54,7 +55,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Execute these instructions based on the given activity and report the result on completion
         /// Can (but must not) be cleared with the <see cref="IVisualInstructor.Clear"/> method
         /// </summary>
-        public static long Execute(this IVisualInstructor instructor, string title, IVisualInstructions parameter, string[] results, Action<ActiveInstructionResponse> callback)
+        public static long Execute(this IVisualInstructor instructor, string title, IVisualInstructions parameter, IReadOnlyList<string> results, Action<ActiveInstructionResponse> callback)
         {
             return instructor.Execute(new ActiveInstruction
             {
@@ -67,7 +68,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// <summary>
         /// Executes the instructions of an activity with defining own results
         /// </summary>
-        public static long Execute(this IVisualInstructor instructor, string title, ActivityStart activityStart, string[] results, Action<ActiveInstructionResponse> callback)
+        public static long Execute(this IVisualInstructor instructor, string title, ActivityStart activityStart, IReadOnlyList<string> results, Action<ActiveInstructionResponse> callback)
         {
             var instructions = GetInstructions(activityStart);
             return instructor.Execute(new ActiveInstruction

--- a/src/Tests/Moryx.ControlSystem.Tests/Moryx.ControlSystem.Tests.csproj
+++ b/src/Tests/Moryx.ControlSystem.Tests/Moryx.ControlSystem.Tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="NUnit" />
 	<PackageReference Include="NUnit3TestAdapter" />
     <PackageReference Include="Moq" />
-	<PackageReference Include="NUnit3TestAdapter" />
 
     <PackageReference Include="Moryx.AbstractionLayer.TestTools" />
   </ItemGroup>


### PR DESCRIPTION
The underlying ActiveInstruction uses IReadOnlyList<string> as well. Therefore there is no need to limit the extension parameter to an array. Moreover, it is inconvenient since the conversion methods of EnumInstructionResult return IReadOnlyList<string> as well. Those results would need to be casted currently

