### PR TITLE
Removed the implementation of Capabilities from Cell

### DIFF
--- a/docs/migrations/v6_to_v8.md
+++ b/docs/migrations/v6_to_v8.md
@@ -42,4 +42,6 @@ VisualInstructor.Execute("Some Title", someInstructions, EnumInstructionResult.P
 ```
 
 ### EnumInstructionAttribute.Title and the corresponding constructor were removed
+- The `Title` property of the `EnumInstructionAttribute` was removed
 - To set the display name of an enum value please use the default data annotation `[Display(Name = "Value's name")]`
+- To hide certain values of an enum from being used as instruction results, please continue to use the `EnumInstructionAttribute`

--- a/src/Moryx.ControlSystem/Cells/Cell.cs
+++ b/src/Moryx.ControlSystem/Cells/Cell.cs
@@ -30,20 +30,7 @@ namespace Moryx.ControlSystem.Cells
         
         /// <inheritdoc />
         public abstract void SequenceCompleted(SequenceCompleted completed);
-        private ICapabilities _capabilities = NullCapabilities.Instance;
-
-        public ICapabilities Capabilities
-        {
-            get
-            {
-                return _capabilities;
-            }
-            protected set
-            {
-                _capabilities = value;
-                this.CapabilitiesChanged?.Invoke(this, _capabilities);
-            }
-        }
+        
         /// <summary>
         /// Publish a <see cref="ReadyToWork"/> from the resource
         /// </summary>
@@ -77,6 +64,5 @@ namespace Moryx.ControlSystem.Cells
 
         /// <inheritdoc />
         public event EventHandler<ActivityCompleted> ActivityCompleted;
-        public event EventHandler<ICapabilities> CapabilitiesChanged;
     }
 }


### PR DESCRIPTION
With the changes to the IResource interface, we accidently added Capabilities with corresponding backing field and the CapabilitiesChanged event to the Cell (in #69). This hides the respective members from the Resource base class in Cell. We removed the unintentional construct.
Also includes an update to the migration guide

