### PR TITLE
Adjust package feed addresses

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,6 +20,12 @@ env:
   dotnet_sdk_version: '7.x'
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   REPOSITORY_NAME: ${{ github.event.repository.name }}
+  MORYX_PACKAGE_TARGET_DEV: 'https://www.myget.org/F/moryx-oss-ci/api/v2/package'
+  MORYX_PACKAGE_TARGET_V3_DEV: 'https://www.myget.org/F/moryx-oss-ci/api/v3/index.json'
+  MORYX_PACKAGE_TARGET_FUTURE: 'https://www.myget.org/F/moryx-oss-ci/api/v2/package'
+  MORYX_PACKAGE_TARGET_V3_FUTURE: 'https://www.myget.org/F/moryx-oss-ci/api/v3/index.json'
+  MORYX_PACKAGE_TARGET_RELEASE: 'https://api.nuget.org/v3/index.json'
+  MORYX_PACKAGE_TARGET_V3_RELEASE: 'https://api.nuget.org/v3/index.json'
 
 jobs:
   Build:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
     </a>
 </p>
 
+<p align="center">
+    <a href="https://www.nuget.org/packages/Moryx/">
+        <img alt="NuGet Release" src="https://img.shields.io/nuget/v/Moryx.ControlSystem?color=0098A1">
+    </a>
+</p>
+
 # MORYX Factory
 
 **Public API definitions for MORYX Factory applications.**
@@ -25,13 +31,13 @@ This repository contains the APIs, domain objects and developer documentation fo
 
 ## Packages
 
-| Package | Stable | Preview | Future |
-|--|--|--|--|
-| `Moryx.ControlSystem` | [![NuGet](https://img.shields.io/nuget/v/Moryx.ControlSystem.svg)](https://www.nuget.org/packages/Moryx.ControlSystem/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.ControlSystem)](https://www.myget.org/feed/moryx/package/nuget/Moryx.ControlSystem) | [![MyGet-Release](https://img.shields.io/myget/moryx-future/vpre/Moryx.ControlSystem)](https://www.myget.org/feed/moryx-future/package/nuget/Moryx.ControlSystem) |
-| `Moryx.Orders` | [![NuGet](https://img.shields.io/nuget/v/Moryx.Orders.svg)](https://www.nuget.org/packages/Moryx.Orders/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.Orders)](https://www.myget.org/feed/moryx/package/nuget/Moryx.Orders) | [![MyGet-Release](https://img.shields.io/myget/moryx-future/vpre/Moryx.Orders)](https://www.myget.org/feed/moryx-future/package/nuget/Moryx.Orders) |
-| `Moryx.Users` | [![NuGet](https://img.shields.io/nuget/v/Moryx.Users.svg)](https://www.nuget.org/packages/Moryx.Users/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.Users)](https://www.myget.org/feed/moryx/package/nuget/Moryx.Users) | [![MyGet-Release](https://img.shields.io/myget/moryx-future/vpre/Moryx.Users)](https://www.myget.org/feed/moryx-future/package/nuget/Moryx.USers) | 
-| `Moryx.ProcessData` | [![NuGet](https://img.shields.io/nuget/v/Moryx.ProcessData.svg)](https://www.nuget.org/packages/Moryx.ProcessData/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.ProcessData)](https://www.myget.org/feed/moryx/package/nuget/Moryx.ProcessData) | [![MyGet-Release](https://img.shields.io/myget/moryx-future/vpre/Moryx.ProcessData)](https://www.myget.org/feed/moryx-future/package/nuget/Moryx.ProcessData) |
-| `Moryx.Simulation` | [![NuGet](https://img.shields.io/nuget/v/Moryx.Simulation.svg)](https://www.nuget.org/packages/Moryx.Simulation/) | [![MyGet](https://img.shields.io/myget/moryx/vpre/Moryx.Simulation)](https://www.myget.org/feed/moryx/package/nuget/Moryx.Simulation) | [![MyGet-Release](https://img.shields.io/myget/moryx-future/vpre/Moryx.Simulation)](https://www.myget.org/feed/moryx-future/package/nuget/Moryx.Simulation) |
+| Package |  |
+|--|--|
+| `Moryx.ControlSystem` |  |
+| `Moryx.Orders` |  |
+| `Moryx.Users` |  | 
+| `Moryx.ProcessData` |  |
+| `Moryx.Simulation` |  |
 ## Contribute
 
 You can contribute to the MORYX Factory Domain by reporting bugs and suggesting extensions to APIs.


### PR DESCRIPTION
Package feed information has been added to the top of README.md and is removed from the list of MORYX packages since that information is only needed once.

