### PR TITLE
Added StateDisplayName to operation for detailed name of classification

### DIFF
--- a/src/Moryx.Orders/Facade/IOrderManagement.cs
+++ b/src/Moryx.Orders/Facade/IOrderManagement.cs
@@ -150,7 +150,7 @@ namespace Moryx.Orders
 
         /// <summary>
         /// Tries to advise the <see cref="Operation"/>. 
-        /// The returned advice result contains information regarding the successful or unsuccesful attempt.
+        /// The returned advice result contains information regarding the successful or unsuccessful attempt.
         /// </summary>
         /// <param name="operation">The <see cref="Operation"/> to advice.</param>
         /// <param name="advice">The <see cref="OperationAdvice"/> to apply on the <see cref="Operation"/>.</param>

--- a/src/Moryx.Orders/Operation.cs
+++ b/src/Moryx.Orders/Operation.cs
@@ -108,12 +108,22 @@ namespace Moryx.Orders
         /// <summary>
         /// Current state classification of this operation
         /// </summary>
-        public virtual OperationClassification State { get => (OperationClassification)((int)FullState & 0xFF); protected set => FullState = value; }
+        public virtual OperationClassification State
+        {
+            get => (OperationClassification)((int)FullState & 0xFF); 
+            protected set => FullState = value;
+        }
 
         /// <summary>
         /// Current state classification of this operation
         /// </summary>
         public virtual OperationClassification FullState { get; protected set; }
+
+        /// <summary>
+        /// Detailed display name of the state
+        /// TODO: Remove this property in next major and replace rework OperationClassification
+        /// </summary>
+        public virtual string StateDisplayName { get; protected set; }
 
         /// <summary>
         /// Source information of the operation

--- a/src/Moryx.Orders/OperationClassification.cs
+++ b/src/Moryx.Orders/OperationClassification.cs
@@ -83,6 +83,11 @@ namespace Moryx.Orders
         /// <summary>
         /// Flag if the operation can be adviced
         /// </summary>
-        CanAdvice = (1 << 20)
+        CanAdvice = (1 << 20),
+
+        /// <summary>
+        /// Flag if the operation is running but has no process
+        /// </summary>
+        IsAmountReached = (1 << 22),
     }
 }

--- a/src/Moryx.Orders/OperationClassification.cs
+++ b/src/Moryx.Orders/OperationClassification.cs
@@ -8,7 +8,7 @@ namespace Moryx.Orders
     /// <summary>
     /// Enum providing the classification of the internal state machine of the operation for an external representation
     /// The lowest 8 bits define the state of the operation. The following 16 bits contain flags for the executable 
-    /// actions on the operation and the trailing 8 bits overal classification information.
+    /// actions on the operation and the trailing 8 bits overall classification information.
     /// Bit:    31 - 24  |  23 - 8  |  7 - 0  |
     /// Flag:     Type   |   Usage  |  State  |
     /// </summary>
@@ -59,7 +59,6 @@ namespace Moryx.Orders
         /// The operation failed in the creation process.
         /// </summary>
         Failed = 11,
-
 
         /// <summary>
         /// Flag if the operation can be reloaded

--- a/src/Moryx.Orders/OperationLogMessage.cs
+++ b/src/Moryx.Orders/OperationLogMessage.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.Extensions.Logging;
-using Moryx.Logging;
 
 namespace Moryx.Orders
 {


### PR DESCRIPTION
The operation does not provide the state `DisplayName` "Amount Reached". In MORYX 4 the state name of the operation was used. In MORYX 6 only the Classification is provided. From the technical point of view it is correct that the classification is shown. For the worker the difference between a currently producing operation and an operation which have reached its amount. 

Also the actions are different: A FinalReport is not possible in the "Running"-State but in "AmountReached". So the worker sees the same state but have different possible actions.

Here: Bringing back a DisplayName proeprty on the model to be displayed in the UI.

I added directly a TODO because in a next major the Classifcation should be reworked. It also should contain AmountReached (same value as running but different meaning).