### PR TITLE
Added state display name for jobs

### DIFF
--- a/src/Moryx.ControlSystem/Cells/Session.cs
+++ b/src/Moryx.ControlSystem/Cells/Session.cs
@@ -16,7 +16,7 @@ namespace Moryx.ControlSystem.Cells
         /// <summary>
         /// Empty array of constraints
         /// </summary>
-        protected static readonly IConstraint[] EmptyConstraints = new IConstraint[0];
+        protected static readonly IConstraint[] EmptyConstraints = Array.Empty<IConstraint>();
 
         /// <summary>
         /// Initialize a new resource request for a certain resource

--- a/src/Moryx.ControlSystem/Jobs/Job.cs
+++ b/src/Moryx.ControlSystem/Jobs/Job.cs
@@ -56,7 +56,13 @@ namespace Moryx.ControlSystem.Jobs
         /// Classification of the job
         /// </summary>
         public JobClassification Classification { get; set; }
-        
+
+        /// <summary>
+        /// Detailed display name of the state
+        /// TODO: Remove this property in next major and replace with reworked JobClassification
+        /// </summary>
+        public virtual string StateDisplayName { get; protected set; }
+
         private IReadOnlyList<IProcess> _runningProcesses;
         /// <summary>
         /// Currently running processes of the job

--- a/src/Moryx.ControlSystem/Jobs/Job.cs
+++ b/src/Moryx.ControlSystem/Jobs/Job.cs
@@ -63,7 +63,7 @@ namespace Moryx.ControlSystem.Jobs
         /// </summary>
         public IReadOnlyList<IProcess> RunningProcesses
         {
-            get => _runningProcesses ?? new IProcess[0];
+            get => _runningProcesses ?? Array.Empty<IProcess>();
             protected set => _runningProcesses = value;
         }
         
@@ -73,7 +73,7 @@ namespace Moryx.ControlSystem.Jobs
         /// </summary>
         public IReadOnlyList<IProcess> AllProcesses
         {
-            get => _allProcesses ?? new IProcess[0];
+            get => _allProcesses ?? Array.Empty<IProcess>();
             protected set => _allProcesses = value;
         }
     }

--- a/src/Moryx.ControlSystem/Jobs/JobSchedulerBase.cs
+++ b/src/Moryx.ControlSystem/Jobs/JobSchedulerBase.cs
@@ -24,7 +24,7 @@ namespace Moryx.ControlSystem.Jobs
         /// <summary>
         /// Empty array for jobs without dependencies
         /// </summary>
-        private readonly Job[] EmptyDependencies = new Job[0];
+        private readonly Job[] EmptyDependencies = Array.Empty<Job>();
 
         /// <summary>
         /// Dependency map that can be helpful for job scheduling

--- a/src/Moryx.ControlSystem/VisualInstructions/ActiveInstruction.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/ActiveInstruction.cs
@@ -34,7 +34,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// Results of the instruction
         /// </summary>
         [Obsolete("Use the result objects in 'Results' property instead!")]
-        public string[] PossibleResults { get; set; } = new string[0];
+        public string[] PossibleResults { get; set; } = Array.Empty<string>();
 
         /// <summary>
         /// Possible results of the instruction

--- a/src/Moryx.Orders/Assignment/Recipes/RecipeAssignmentBase.cs
+++ b/src/Moryx.Orders/Assignment/Recipes/RecipeAssignmentBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2021, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -55,7 +56,7 @@ namespace Moryx.Orders.Assignment
         {
             var product = ProductManagement.LoadType(identity);
             if (product == null)
-                return Task.FromResult<IReadOnlyList<IProductRecipe>>(new IProductRecipe[0]);
+                return Task.FromResult<IReadOnlyList<IProductRecipe>>(Array.Empty<IProductRecipe>());
 
             var recipes = ProductManagement.GetRecipes(product, RecipeClassification.Default | RecipeClassification.Alternative);
             return Task.FromResult(recipes);


### PR DESCRIPTION
Same as in #80. The classification is missleading and does not provide all information to verify the current state. The real display name of the state should be shown on the UI.

First commit is just a cleanup: Usage of Array.Empty in whole solution