### PR TITLE
Session context struct avoids changes on previos sequence

### DIFF
--- a/src/Moryx.ControlSystem/Cells/ReadyToWork.cs
+++ b/src/Moryx.ControlSystem/Cells/ReadyToWork.cs
@@ -52,10 +52,8 @@ namespace Moryx.ControlSystem.Cells
         /// </summary>
         /// <param name="activity">The activity.</param>
         public ActivityStart StartActivity(IActivity activity)
-        {
-            // Update process before next stage
-            Process = activity.Process;
-            return new ActivityStart(this, activity);
+        {           
+            return new ActivityStart(this, activity) { Process = activity.Process };
         }
 
         /// <summary>
@@ -63,9 +61,7 @@ namespace Moryx.ControlSystem.Cells
         /// </summary>
         public SequenceCompleted CompleteSequence(IProcess process, bool processActive, params long[] nextCells)
         {
-            // Update process before next stage
-            Process = process;
-            return new SequenceCompleted(this, processActive, nextCells);
+            return new SequenceCompleted(this, processActive, nextCells) { Process = process };
         }
 
         /// <summary>

--- a/src/Moryx.ControlSystem/Cells/Session.cs
+++ b/src/Moryx.ControlSystem/Cells/Session.cs
@@ -37,7 +37,7 @@ namespace Moryx.ControlSystem.Cells
         /// <summary>
         /// Context class holding all session information
         /// </summary>
-        private readonly SessionContext _context;
+        private SessionContext _context;
 
         /// <summary>
         /// Unique id of the current production transaction
@@ -134,24 +134,27 @@ namespace Moryx.ControlSystem.Cells
 
         #endregion
 
-        private class SessionContext
+        private struct SessionContext
         {
             internal SessionContext(ActivityClassification classification, Guid sessionId, ProcessReference reference)
             {
                 Classification = classification;
                 SessionId = sessionId;
                 Reference = reference;
+
+                Tag = null;
+                Process = null;
             }
 
-            public Guid SessionId { get; }
+            public Guid SessionId;
 
-            public IProcess Process { get; set; }
+            public IProcess Process;
 
-            public ProcessReference Reference { get; set; }
+            public ProcessReference Reference;
 
-            public ActivityClassification Classification { get; }
+            public ActivityClassification Classification;
 
-            public object Tag { get; set; }
+            public object Tag;
         }
     }
 }

--- a/src/Tests/Moryx.ControlSystem.Tests/ProductionSessionTests.cs
+++ b/src/Tests/Moryx.ControlSystem.Tests/ProductionSessionTests.cs
@@ -46,10 +46,11 @@ namespace Moryx.ControlSystem.Tests
         {
             var readyToWork = Session.StartSession(ActivityClassification.Production, ReadyToWorkType.Pull, 4242);
 
-            var activityStart = readyToWork.StartActivity(new DummyActivity { Process = new Process() });
+            var activityStart = readyToWork.StartActivity(new DummyActivity { Process = new Process { Id = 4242 } });
 
             Assert.AreEqual(readyToWork.Reference, activityStart.Reference);
             Assert.AreEqual(readyToWork.Id, activityStart.Id);
+            Assert.AreNotEqual(readyToWork.Process, activityStart.Process); // Make sure process is not populated back to RTW
         }
 
         [Test]
@@ -82,7 +83,7 @@ namespace Moryx.ControlSystem.Tests
         {
             var readyToWork = Session.StartSession(ActivityClassification.Production, ReadyToWorkType.Pull, 4242);
 
-            var activityStart = readyToWork.StartActivity(new DummyActivity { Process = new Process() });
+            var activityStart = readyToWork.StartActivity(new DummyActivity { Process = new Process { Id = 4242 } });
             activityStart.Activity.Complete(1);
 
             var activityCompleted = activityStart.CreateResult();
@@ -96,7 +97,7 @@ namespace Moryx.ControlSystem.Tests
         {
             var readyToWork = Session.StartSession(ActivityClassification.Production, ReadyToWorkType.Pull, 4242);
 
-            var activityStart = readyToWork.StartActivity(new DummyActivity {Process = new Process()});
+            var activityStart = readyToWork.StartActivity(new DummyActivity { Process = new Process { Id = 4242 } });
             activityStart.Activity.Complete(1);
 
             var activityCompleted = activityStart.CreateResult();
@@ -123,7 +124,7 @@ namespace Moryx.ControlSystem.Tests
         {
             var readyToWork = Session.StartSession(ActivityClassification.Production, readyToWorkType, 4242);
 
-            var activityStart = readyToWork.StartActivity(new DummyActivity { Process = new Process() });
+            var activityStart = readyToWork.StartActivity(new DummyActivity { Process = new Process { Id = 4242 } });
             activityStart.Activity.Complete(1);
 
             var activityCompleted = activityStart.CreateResult();


### PR DESCRIPTION
Because the session context was a reference type, it also updated all previous sequence objects from the session, which could cause unwanted side effects.