### PR TITLE
Add `UnknownActivityAborted` session

### DIFF
--- a/src/Moryx.ControlSystem/Activities/ActivityClassification.cs
+++ b/src/Moryx.ControlSystem/Activities/ActivityClassification.cs
@@ -16,6 +16,11 @@ namespace Moryx.ControlSystem.Activities
     public enum ActivityClassification
     {
         /// <summary>
+        /// Use in case the activity classification is unkown
+        /// </summary>
+        Unknown = 0x00,
+
+        /// <summary>
         /// Default classification is production
         /// </summary>
         Production = 0x01,
@@ -33,6 +38,6 @@ namespace Moryx.ControlSystem.Activities
         /// <summary>
         /// Activity performs a preparation, for example for a <see cref="Production"/> activity
         /// </summary>
-        Preparation = 0x08
+        Preparation = 0x08,
     }
 }

--- a/src/Moryx.ControlSystem/Cells/ActivityCompleted.cs
+++ b/src/Moryx.ControlSystem/Cells/ActivityCompleted.cs
@@ -10,9 +10,6 @@ namespace Moryx.ControlSystem.Cells
     /// </summary>
     public class ActivityCompleted : Session, ICompletableSession
     {
-        /// <summary>
-        /// Initialize a new resource request for a certain resource
-        /// </summary>
         internal ActivityCompleted(IActivity completed, Session currentSession)
             : base(currentSession)
         {

--- a/src/Moryx.ControlSystem/Cells/Session.cs
+++ b/src/Moryx.ControlSystem/Cells/Session.cs
@@ -125,6 +125,20 @@ namespace Moryx.ControlSystem.Cells
             return CreateSession(classification, type, ProcessReference.InstanceIdentity(identity), constraints);
         }
 
+
+        /// <summary>
+        /// Creates a new <see cref="Session"/> for the <paramref name="unknown"/> activity
+        /// with a new session context and marks the activity as failed.
+        /// </summary>
+        /// <param name="unknown"></param>
+        public static UnknownActivityAborted WrapUnknownActivity(IActivity unknown)
+        {
+            unknown.Fail();
+            var wrapper = StartSession(ActivityClassification.Unknown, ReadyToWorkType.Unset, unknown.Process.Id)
+                .CompleteSequence(null, false, new long[] { });
+            return new UnknownActivityAborted(unknown, wrapper);
+        }
+
         private static ReadyToWork CreateSession(ActivityClassification classification, ReadyToWorkType type, ProcessReference reference, IConstraint[] constraints)
         {
             if (constraints == null)

--- a/src/Moryx.ControlSystem/Cells/UnknownActivityAborted.cs
+++ b/src/Moryx.ControlSystem/Cells/UnknownActivityAborted.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2024, Phoenix Contact GmbH & Co. KG
+// Licensed under the Apache License, Version 2.0
+
+using Moryx.AbstractionLayer;
+
+namespace Moryx.ControlSystem.Cells
+{
+    /// <summary>
+    /// Message send by the resource managment when it aborted an activity for an 
+    /// unkown session.
+    /// </summary>
+    public class UnknownActivityAborted : ActivityCompleted
+    {
+        internal UnknownActivityAborted(IActivity aborted, Session wrapper)
+            : base(aborted, wrapper)
+        {
+            aborted.Fail();
+            AbortedActivity = aborted;
+        }
+
+        /// <summary>
+        /// Activity that was aborted
+        /// </summary>
+        public IActivity AbortedActivity { get; }
+    }
+}


### PR DESCRIPTION
The new type is a session-wrapper for activities that should be aborted, but for which the session is unknown for a cell. It can be created and uses a new session context.

_Note:_ Adding the feature in the support only release simplifies bug fixes in downstream projects. This is the only reason for this exception