### PR TITLE
Fixed enum result conversion for Execute<TEnum> in VisualInstructorExtensions

### DIFF
--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
@@ -142,7 +142,7 @@ namespace Moryx.ControlSystem.VisualInstructions
                     if (result.SelectedResult?.Key == null)
                         callback(EnumInstructionResult.ResultToGenericEnumValue<T>(result.Result));
                     else
-                        callback(EnumInstructionResult.ResultToGenericEnumValue<T>(result.SelectedResult));
+                        callback(EnumInstructionResult.ResultToGenericEnumValue<T>(result.SelectedResult.Key));
                 });
         }
 


### PR DESCRIPTION
The `ResultToGenericEnumValue(InstructionResult)` is not correct here, because `EnumsturcionResult.PossibleResults(Type)` is used during execute, therefore the `ResultToGenericEnumValue(string)` must be used:
