### PR TITLE
Extend IMountingActivity to request empty Wpcs

### DIFF
--- a/src/Moryx.ControlSystem/Activities/IMountingActivity.cs
+++ b/src/Moryx.ControlSystem/Activities/IMountingActivity.cs
@@ -36,4 +36,17 @@ namespace Moryx.ControlSystem.Activities
         /// </summary>
         MountOperation Operation { get; }
     }
+
+    /// <summary>
+    /// Special interface to identify activities that perform mount operations
+    /// </summary>
+    public interface IMountingActivityExtended : IMountingActivity
+    {
+        /// <summary>
+        /// Flag to trigger wpc routing to provide a empty wpc for this activity.
+        /// </summary>
+        bool EmptyWpcRequired { get; }
+    }
+
+
 }

--- a/src/Moryx.ControlSystem/Activities/IMountingActivity.cs
+++ b/src/Moryx.ControlSystem/Activities/IMountingActivity.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2021, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
+using System;
 using Moryx.AbstractionLayer;
 
 namespace Moryx.ControlSystem.Activities
@@ -40,7 +41,8 @@ namespace Moryx.ControlSystem.Activities
     /// <summary>
     /// Special interface to identify activities that perform mount operations
     /// </summary>
-    public interface IMountingActivityExtended : IMountingActivity
+    [Obsolete("Will be merged into IMountingActivity within the next Major version!")]
+    public interface IEmptyWpcRequiredMountingActivity : IMountingActivity
     {
         /// <summary>
         /// Flag to trigger wpc routing to provide a empty wpc for this activity.


### PR DESCRIPTION
Adding a extended IMountingActivity Interface. Let the activity signalize the need of an empty wpc.
Before the only way to get a empty WPC was setting the ProcessRequirement to Empty this makes it impossible to get a WPC for a running process. 