### PR TITLE
SMAF-4654: Set default machine location to visible coordinates

### DIFF
--- a/src/Moryx.Factory/MachineLocation.cs
+++ b/src/Moryx.Factory/MachineLocation.cs
@@ -11,48 +11,48 @@ using Moryx.Serialization;
 
 namespace Moryx.Factory
 {
-    /// <summary>
-    /// Class for MachineLocation in the factory
-    /// </summary>
-    public class MachineLocation : PublicResource, IMachineLocation
-    {
-        public IPublicResource Machine => Children.OfType<ICell>().FirstOrDefault();
-
-        [DataMember, EntrySerialize]
-        public string SpecificIcon { get; set; }
-
-        [DataMember, EntrySerialize]
-        public string Image { get; set; }
-
         /// <summary>
-        /// X position of the location
+        /// Class for MachineLocation in the factory
         /// </summary>
-        [DataMember, EntrySerialize, DefaultValue(10)]
-        public double PositionX { get; set; }
-
-        /// <summary>
-        /// Y position of the location
-        /// </summary>
-        [DataMember, EntrySerialize, DefaultValue(10)]
-        public double PositionY { get; set; }
-
-        public Position Position
+        public class MachineLocation : PublicResource, IMachineLocation
         {
-            get => new() { PositionX = PositionX, PositionY = PositionY };
-            set
-            {
-                PositionX = value.PositionX;
-                PositionY = value.PositionY;
-            }
+                public IPublicResource Machine => Children.OfType<ICell>().FirstOrDefault();
+
+                [DataMember, EntrySerialize]
+                public string SpecificIcon { get; set; }
+
+                [DataMember, EntrySerialize]
+                public string Image { get; set; }
+
+                /// <summary>
+                /// X position of the location
+                /// </summary>
+                [DataMember, EntrySerialize, DefaultValue(0.5)]
+                public double PositionX { get; set; }
+
+                /// <summary>
+                /// Y position of the location
+                /// </summary>
+                [DataMember, EntrySerialize, DefaultValue(0.5)]
+                public double PositionY { get; set; }
+
+                public Position Position
+                {
+                        get => new() { PositionX = PositionX, PositionY = PositionY };
+                        set
+                        {
+                                PositionX = value.PositionX;
+                                PositionY = value.PositionY;
+                        }
+                }
+
+                [ResourceReference(ResourceRelationType.TransportRoute, ResourceReferenceRole.Source)]
+                public IReferences<ITransportPath> Origins { get; set; }
+
+                [ResourceReference(ResourceRelationType.TransportRoute, ResourceReferenceRole.Target)]
+                public IReferences<ITransportPath> Destinations { get; set; }
+
+                IEnumerable<ITransportPath> ILocation.Origins => Origins;
+                IEnumerable<ITransportPath> ILocation.Destinations => Destinations;
         }
-
-        [ResourceReference(ResourceRelationType.TransportRoute, ResourceReferenceRole.Source)]
-        public IReferences<ITransportPath> Origins { get; set; }
-
-        [ResourceReference(ResourceRelationType.TransportRoute, ResourceReferenceRole.Target)]
-        public IReferences<ITransportPath> Destinations { get; set; }
-
-        IEnumerable<ITransportPath> ILocation.Origins => Origins;
-        IEnumerable<ITransportPath> ILocation.Destinations => Destinations;
-    }
 }


### PR DESCRIPTION
- Previously, new machines were intialized at position (10,10), placing them outside the visible are of the factory monitor
- Updated the default location to (0.5, 0.5) to ensure newly created resources are always visible and interactable

