### PR TITLE
Add automatic support for Inputs to the VisualInstructionParameters

### DIFF
--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstruction.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstruction.cs
@@ -54,6 +54,7 @@ namespace Moryx.ControlSystem.VisualInstructions
     /// <summary>
     /// Interface for classes that define instructions
     /// </summary>
+    //TODO: remove  in MORYX 10, will be replaced by VisualInstructionParameters
     public interface IVisualInstructions
     {
         /// <summary>

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructionParameters.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructionParameters.cs
@@ -20,6 +20,11 @@ namespace Moryx.ControlSystem.VisualInstructions
         public VisualInstruction[] Instructions { get; set; }
 
         /// <summary>
+        /// Inputs for this activity.
+        /// </summary>
+        public object Inputs { get; set; }
+
+        /// <summary>
         /// Binder to resolve visual instruction bindings
         /// </summary>
         protected VisualInstructionBinder InstructionBinder { get; private set; }

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
@@ -26,6 +26,7 @@ namespace Moryx.ControlSystem.VisualInstructions
             {
                 Title = title,
                 Instructions = parameter.Instructions,
+                //TODO: remove the casting in MORYX 10
                 Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             });
         }
@@ -40,6 +41,7 @@ namespace Moryx.ControlSystem.VisualInstructions
             {
                 Title = title,
                 Instructions = parameter.Instructions,
+                //TODO: remove the casting in MORYX 10
                 Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             }, autoClearMs);
         }
@@ -54,6 +56,7 @@ namespace Moryx.ControlSystem.VisualInstructions
             {
                 Title = title,
                 Instructions = instructions,
+                //TODO: remove the casting in MORYX 10
                 Inputs = (activityStart.Activity.Parameters as VisualInstructionParameters)?.Inputs,
             });
         }
@@ -127,6 +130,8 @@ namespace Moryx.ControlSystem.VisualInstructions
                 Title = title,
                 Instructions = parameter.Instructions,
                 PossibleResults = results,
+                Results = results.Select(r => new InstructionResult { Key = r, DisplayValue = r }).ToArray(),
+                //TODO: remove the casting in MORYX 10
                 Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             }, callback);
         }
@@ -163,6 +168,7 @@ namespace Moryx.ControlSystem.VisualInstructions
                 Instructions = instructions,
                 PossibleResults = results,
                 Results = results.Select(r => new InstructionResult { Key = r, DisplayValue = r }).ToArray(),
+                //TODO: remove the casting in MORYX 10
                 Inputs = (activityStart.Activity.Parameters as VisualInstructionParameters)?.Inputs,
             }, callback);
         }

--- a/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/VisualInstructorExtensions.cs
@@ -1,10 +1,11 @@
-﻿// Copyright (c) 2024, Phoenix Contact GmbH & Co. KG
+// Copyright (c) 2024, Phoenix Contact GmbH & Co. KG
 // Licensed under the Apache License, Version 2.0
 
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Metadata;
 using Moryx.AbstractionLayer;
 using Moryx.ControlSystem.Cells;
 
@@ -24,7 +25,8 @@ namespace Moryx.ControlSystem.VisualInstructions
             return instructor.Display(new ActiveInstruction
             {
                 Title = title,
-                Instructions = parameter.Instructions
+                Instructions = parameter.Instructions,
+                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             });
         }
 
@@ -37,7 +39,8 @@ namespace Moryx.ControlSystem.VisualInstructions
             instructor.Display(new ActiveInstruction
             {
                 Title = title,
-                Instructions = parameter.Instructions
+                Instructions = parameter.Instructions,
+                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             }, autoClearMs);
         }
 
@@ -50,7 +53,8 @@ namespace Moryx.ControlSystem.VisualInstructions
             return instructor.Display(new ActiveInstruction
             {
                 Title = title,
-                Instructions = instructions
+                Instructions = instructions,
+                Inputs = (activityStart.Activity.Parameters as VisualInstructionParameters)?.Inputs,
             });
         }
 
@@ -122,7 +126,8 @@ namespace Moryx.ControlSystem.VisualInstructions
             {
                 Title = title,
                 Instructions = parameter.Instructions,
-                PossibleResults = results
+                PossibleResults = results,
+                Inputs = (parameter as VisualInstructionParameters)?.Inputs,
             }, callback);
         }
 
@@ -157,7 +162,8 @@ namespace Moryx.ControlSystem.VisualInstructions
                 Title = title,
                 Instructions = instructions,
                 PossibleResults = results,
-                Results = results.Select(r => new InstructionResult { Key = r, DisplayValue = r }).ToArray()
+                Results = results.Select(r => new InstructionResult { Key = r, DisplayValue = r }).ToArray(),
+                Inputs = (activityStart.Activity.Parameters as VisualInstructionParameters)?.Inputs,
             }, callback);
         }
 


### PR DESCRIPTION
Added the Inputs property to the VisualInstructionParameters base class and update the `VisualInstrucot.Execute` methods to pass the inputs from the parameters to the ActiveInstruction

