### PR TITLE
Fix return-type for `PossibleInstructionResult` of EnumInstructionResult

### DIFF
--- a/src/Moryx.ControlSystem/VisualInstructions/EnumInstructionResult.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/EnumInstructionResult.cs
@@ -24,6 +24,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// <summary>
         /// Determine possible string buttons from enum result
         /// </summary>
+        [Obsolete("Use the 'InstructionResults' method instead!'")]
         public static IReadOnlyList<InstructionResult> PossibleInstructionResults(Type resultEnum, params string[] exceptions)
         {
             return ParseEnum(resultEnum, exceptions).Select(pair => new InstructionResult
@@ -31,6 +32,18 @@ namespace Moryx.ControlSystem.VisualInstructions
                 Key = pair.Value.ToString("D"),
                 DisplayValue = pair.Key
             }).ToList();
+        }
+
+        /// <summary>
+        /// Determine possible string buttons from enum result
+        /// </summary>
+        public static InstructionResult[] InstructionResults(Type resultEnum, params string[] exceptions)
+        {
+            return ParseEnum(resultEnum, exceptions).Select(pair => new InstructionResult
+            {
+                Key = pair.Value.ToString("D"),
+                DisplayValue = pair.Key
+            }).ToArray();
         }
 
         /// <summary>

--- a/src/Moryx.ControlSystem/VisualInstructions/EnumInstructionResult.cs
+++ b/src/Moryx.ControlSystem/VisualInstructions/EnumInstructionResult.cs
@@ -5,6 +5,7 @@ using Moryx.Tools;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Globalization;
 
 namespace Moryx.ControlSystem.VisualInstructions
 {
@@ -29,7 +30,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         {
             return ParseEnum(resultEnum, exceptions).Select(pair => new InstructionResult
             {
-                Key = pair.Value.ToString("D"),
+                Key = pair.Value.ToString("D", CultureInfo.InvariantCulture),
                 DisplayValue = pair.Key
             }).ToList();
         }
@@ -41,7 +42,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         {
             return ParseEnum(resultEnum, exceptions).Select(pair => new InstructionResult
             {
-                Key = pair.Value.ToString("D"),
+                Key = pair.Value.ToString("D", CultureInfo.InvariantCulture),
                 DisplayValue = pair.Key
             }).ToArray();
         }
@@ -59,7 +60,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         /// </summary>
         public static int ResultToEnumValue(Type resultEnum, InstructionResult result)
         {
-            return int.Parse(result.Key);
+            return int.Parse(result.Key, CultureInfo.InvariantCulture);
         }
 
         /// <summary>
@@ -92,7 +93,7 @@ namespace Moryx.ControlSystem.VisualInstructions
         public static TEnum ResultToGenericEnumValue<TEnum>(InstructionResult result)
             where TEnum : Enum
         {
-            var numeric = int.Parse(result.Key);
+            var numeric = int.Parse(result.Key, CultureInfo.InvariantCulture);
             return (TEnum)Enum.ToObject(typeof(TEnum), numeric);
         }
 


### PR DESCRIPTION
Since the ActiveInstrucion marks it's property `PossibleResults` of type `IReadOnlyList` as obsolete, I also marked the `PossibleInstructionResult()` method of `EnumInstructionResult` as obsolete and added the method `InstructionResults()` which returns the same data as `PossibleInstructionResult()` but as an array.